### PR TITLE
upgrade to externpro 18.04.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 project(ovsrpro)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}) # Findexternpro.cmake
-set(externpro_REV 18.01.1)
+set(externpro_REV 18.04.1)
 find_package(externpro REQUIRED)
 list(APPEND CMAKE_MODULE_PATH ${externpro_DIR}/share/cmake)
 include(macpro)


### PR DESCRIPTION
closes #43 

This also closes #16. When I run CMake to build ovsrpro using externpro 18.04.1, the projects readme file doesn't change.