### PR TITLE
remove openssl from Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 project(ovsrpro)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}) # Findexternpro.cmake
-set(externpro_REV 18.01.1)
+set(externpro_REV 18.04.1)
 find_package(externpro REQUIRED)
 list(APPEND CMAKE_MODULE_PATH ${externpro_DIR}/share/cmake)
 include(macpro)

--- a/projects/qt5.cmake
+++ b/projects/qt5.cmake
@@ -39,7 +39,6 @@ macro(setConfigureOptions)
     -qt-libjpeg
     -system-freetype
     -opengl desktop
-    -openssl
     -sql-psql
     -psql_config ${STAGE_DIR}/bin/pg_config
     -opensource


### PR DESCRIPTION
## Issues

- #46 

## Summary

I just removed the flag `-openssl` from the configure flags for Qt5.