### PR TITLE
Remove OpenSSL from Qt5

### DIFF
--- a/projects/qt5.cmake
+++ b/projects/qt5.cmake
@@ -39,7 +39,6 @@ macro(setConfigureOptions)
     -qt-libjpeg
     -system-freetype
     -opengl desktop
-    -openssl
     -sql-psql
     -psql_config ${STAGE_DIR}/bin/pg_config
     -opensource


### PR DESCRIPTION
Qt5 needs to be built without OpenSSL.