### PR TITLE
Fix building ZooKeeper

### DIFF
--- a/patches/zookeeper.patch
+++ b/patches/zookeeper.patch
@@ -1,0 +1,15 @@
+diff --git a/build.xml b/build.xml
+index 8562000f7..4653db92b 100644
+--- a/build.xml
++++ b/build.xml
+@@ -36,8 +36,8 @@ xmlns:maven="antlib:org.apache.maven.artifact.ant">
+     <property name="revision.properties" value="revision.properties" />
+     <property file="${basedir}/src/java/${revision.properties}" />
+     
+-    <property name="javac.target" value="1.5" />
+-    <property name="javac.source" value="1.5" />
++    <property name="javac.target" value="1.7" />
++    <property name="javac.source" value="1.7" />
+ 
+     <property name="src.dir" value="${basedir}/src" />
+     <property name="java.src.dir" value="${src.dir}/java/main" />

--- a/projects/zookeeper.cmake
+++ b/projects/zookeeper.cmake
@@ -12,6 +12,8 @@ set(ZK_INSTALL_PATH ${CMAKE_BINARY_DIR}/xpbase/Install/zookeeper)
 set(ZK_VER 3.4.9)
 if(WIN32)
   set(ZOO_PATCH ${PATCH_DIR}/zookeeper-windows.patch)
+else()
+  set(ZOO_PATCH "${PATCH_DIR}/zookeeper.patch")
 endif()
 set(PRO_ZOOKEEPER
   NAME zookeeper
@@ -127,7 +129,11 @@ function(build_zookeeper)
     ExternalProject_Add(zookeeper_Release DEPENDS zookeeper_configure
       DOWNLOAD_COMMAND "" DOWNLOAD_DIR ${NULL_DIR}
       SOURCE_DIR ${SOURCE_DIR}/src/c
-      CONFIGURE_COMMAND ./configure --without-cppunit --prefix=${STAGE_DIR}
+      CONFIGURE_COMMAND
+        CFLAGS=-Wno-error
+        ./configure
+        --without-cppunit
+        --prefix=${STAGE_DIR}
       BUILD_COMMAND $(MAKE) clean && $(MAKE)
       BUILD_IN_SOURCE 1
       INSTALL_COMMAND $(MAKE) install
@@ -138,7 +144,12 @@ function(build_zookeeper)
       ExternalProject_Add(zookeeper_Debug DEPENDS zookeeper_Release
         DOWNLOAD_COMMAND "" DOWNLOAD_DIR ${NULL_DIR}
         SOURCE_DIR ${SOURCE_DIR}/src/c
-        CONFIGURE_COMMAND ./configure --without-cppunit --libdir=${STAGE_DIR}/lib/zookeeperDebug --enable-debug
+        CONFIGURE_COMMAND
+          CFLAGS=-Wno-error
+          ./configure
+          --without-cppunit
+          --libdir=${STAGE_DIR}/lib/zookeeperDebug
+          --enable-debug
         BUILD_COMMAND $(MAKE) clean && $(MAKE)
         BUILD_IN_SOURCE 1
         INSTALL_COMMAND $(MAKE) install-libLTLIBRARIES


### PR DESCRIPTION
- I added a patch to use later source and target properties in the
  build.xml file.
- I disabled treating warnings as errors for release and debug builds.
  This is required to build with GCC 9, and probably others.

closes #76